### PR TITLE
changed leftover Facade project goal prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
 				<artifactId>maven-plugin-plugin</artifactId>
 				<version>3.2</version>
 				<configuration>
-					<goalPrefix>facade-maven-plugin</goalPrefix>
+					<goalPrefix>dietmojo</goalPrefix>
 					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -95,23 +95,28 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.2</version>
+				<version>3.4</version>
 				<configuration>
 					<goalPrefix>dietmojo</goalPrefix>
-					<skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
 				</configuration>
 				<executions>
 					<execution>
-						<id>mojo-descriptor</id>
+						<id>default-descriptor</id>
 						<goals>
 							<goal>descriptor</goal>
 						</goals>
+						<phase>
+							process-classes
+						</phase>
 					</execution>
 					<execution>
-						<id>help-goal</id>
+						<id>help-descriptor</id>
 						<goals>
 							<goal>helpmojo</goal>
 						</goals>
+						<phase>
+							process-classes
+						</phase>
 					</execution>
 				</executions>
 			</plugin>


### PR DESCRIPTION
to remove “[WARNING] Goal prefix is specified as:
'facade-maven-plugin'. Maven currently expects it to be 'dietmojo'.”
